### PR TITLE
Add centralized config file instead of multiple loading of dotenv 

### DIFF
--- a/chroma_db/chroma_vector_db.py
+++ b/chroma_db/chroma_vector_db.py
@@ -17,6 +17,7 @@ from utils.status import Status
 import traceback
 import sys
 import os
+from config import CHROMA_HOST, CHROMA_PORT
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -27,17 +28,6 @@ logging.basicConfig(level=logging.INFO)
 class PaperData(TypedDict):
     embedding: List[float]
     hash: str
-
-
-# When locally testing application and files this will allow us to set a localhost connection
-# since otherwise the application will try to connect to the Docker container, which the file
-# is running outside of and hence does not have access to.
-# In production, the Docker container will set these env-vars to the correct values.
-# For testing run like this:
-# docker compose up -d chromadb
-# CHROMA_HOST=localhost python -m llm.tools.paper_handling_tools
-CHROMA_HOST = os.getenv("CHROMA_HOST", "chromadb")  # default for Docker
-CHROMA_PORT = int(os.getenv("CHROMA_PORT", 8000))
 
 
 class ChromaVectorDB:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,70 @@
+"""
+Centralized configuration loader for the Capstone project.
+
+This module must be imported before any other project modules to ensure
+environment variables are loaded consistently across the application.
+
+All environment variable loading happens here in one place to ensure:
+- Consistent behavior across all modules
+- Easy testing with mocked configurations
+- Single source of truth for configuration
+- Clear documentation of all required environment variables
+"""
+
+import os
+from dotenv import load_dotenv
+
+# Load environment variables once at module import
+load_dotenv()
+
+# Test mode configuration
+TEST_MODE = os.getenv("TEST_MODE") == "true"
+
+# Database configuration
+DB_HOST = os.getenv("DB_HOST", "127.0.0.1")
+DB_PORT = os.getenv("DB_PORT", "5432")
+DB_NAME = os.getenv("DB_NAME", "papers")
+DB_USER = os.getenv("DB_USER", "user")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+# API Keys
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+# Clerk Authentication
+CLERK_SECRET_KEY = os.getenv("CLERK_SECRET_KEY")
+CLERK_PUBLISHABLE_KEY = os.getenv("CLERK_PUBLISHABLE_KEY")
+CLERK_FRONTEND_API_URL = os.getenv("CLERK_FRONTEND_API_URL")
+HOSTNAME = os.getenv("HOSTNAME")
+
+# ChromaDB configuration
+CHROMA_HOST = os.getenv("CHROMA_HOST", "chromadb")  # default for Docker
+CHROMA_PORT = int(os.getenv("CHROMA_PORT", "8000"))
+
+# Newsletter update interval (days)
+DAYS_FOR_UPDATE = 7
+
+
+def validate_required_env_vars():
+    """
+    Validate that all required environment variables are set.
+
+    Raises:
+        ValueError: If any required environment variable is missing.
+    """
+    if TEST_MODE:
+        # In test mode, don't validate Clerk vars
+        return
+
+    required_vars = {
+        "CLERK_SECRET_KEY": CLERK_SECRET_KEY,
+        "CLERK_PUBLISHABLE_KEY": CLERK_PUBLISHABLE_KEY,
+        "CLERK_FRONTEND_API_URL": CLERK_FRONTEND_API_URL,
+        "HOSTNAME": HOSTNAME,
+    }
+
+    missing = [name for name, value in required_vars.items() if not value]
+
+    if missing:
+        raise ValueError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )

--- a/database/database_connection.py
+++ b/database/database_connection.py
@@ -1,17 +1,17 @@
 import psycopg2
-import os
+from config import DB_HOST, DB_NAME, DB_USER, DB_PASSWORD, DB_PORT
 
 
 def connect_to_db():  # outside_chroma=False)
     """
     Establishes a connection to the PostgreSQL database.
-    Reads connection parameters from environment variables.
+    Reads connection parameters from centralized config module.
     """
-    db_host = os.getenv("DB_HOST", "127.0.0.1")
-    db_name = os.getenv("DB_NAME", "papers")
-    db_user = os.getenv("DB_USER", "user")
-    db_password = os.getenv("DB_PASSWORD")
-    db_port = os.getenv("DB_PORT", "5432")
+    db_host = DB_HOST
+    db_name = DB_NAME
+    db_user = DB_USER
+    db_password = DB_PASSWORD
+    db_port = DB_PORT
 
     try:
         return psycopg2.connect(

--- a/database/papers_database_handler.py
+++ b/database/papers_database_handler.py
@@ -12,13 +12,10 @@ All database operations are designed to be robust, transactional, and reusable b
 
 import psycopg2
 from psycopg2 import extras
-from dotenv import load_dotenv
 import hashlib
 from utils.status import Status
 import json
 from database.database_connection import connect_to_db
-
-load_dotenv()
 
 
 def _generate_paper_hash(paper_data_dict):

--- a/evaluation/bm25_lexical_matching.py
+++ b/evaluation/bm25_lexical_matching.py
@@ -1,13 +1,10 @@
 from typing import List, Dict
 from llama_index.core.schema import TextNode
 from llama_index.retrievers.bm25 import BM25Retriever
-from dotenv import load_dotenv
 import Stemmer
 import json
 import os
 from datetime import datetime
-
-load_dotenv()
 
 
 def evaluate_bm25_lexical_matching(

--- a/evaluation/evaluation_dataset.py
+++ b/evaluation/evaluation_dataset.py
@@ -3,7 +3,6 @@ import requests
 from pypdf import PdfReader
 import io
 import os
-from dotenv import load_dotenv
 import openai
 import csv
 import random
@@ -474,8 +473,9 @@ def generate_pairs_csv(citing_paper, papers_list, label, filename="paper_pairs.c
 
 if __name__ == "__main__":
     # To use the OpenAI implementation, change the line below to:
-    load_dotenv()
-    openai.api_key = os.getenv("OPENAI_API_KEY")
+    from config import OPENAI_API_KEY
+
+    openai.api_key = OPENAI_API_KEY
     finder = OpenAIPapersFinder()
 
     # finder = MockPapersFinder()

--- a/llm/LLMDefinition.py
+++ b/llm/LLMDefinition.py
@@ -7,12 +7,8 @@ Responsibilities:
 - Exposes the default LLM instance for use throughout the codebase
 """
 
-import os
 from langchain_openai import ChatOpenAI
-from dotenv import load_dotenv
-
-load_dotenv()
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+from config import OPENAI_API_KEY
 
 if not OPENAI_API_KEY:
     raise ValueError(


### PR DESCRIPTION
## Description

Before the dontenv file was loaded all over the place. This led to inconsistent behaviour, especially when running only part of the app.
The best approach here is to create a centralised config file where all environment is loading in one place (single source of truth) that can then be called as a config at the start of script that needs it this will ease up testing (mock config file instead of env vars), get us a better validation and consistent behaviour.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix
